### PR TITLE
Use tomllib instead of tomli in Python 3.11

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dh-python (5.20230130-0deepin1) unstable; urgency=medium
+
+  * Non-maintainer upload.
+  * Use tomllib in python3 (>> 3.11)
+
+ -- Tianyu Chen <chentianyu1@uniontech.com>  Mon, 13 Mar 2023 14:49:46 +0800
+
 dh-python (5.20230130) unstable; urgency=medium
 
   * pybuild.pm: Export SETUPTOOLS_SCM_PRETEND_VERSION for packages using

--- a/debian/control
+++ b/debian/control
@@ -43,7 +43,7 @@ Depends:
  dh-python (= ${source:Version}),
  python3-build (>> 0.7~),
  python3-installer,
- python3-tomli,
+ python3-tomli | python3 (>> 3.11),
  ${misc:Depends}
 Description: Debian helper tools for packaging Python libraries using PEP517
  This metapackage depends on the components necessary for building packages

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+tomllib.patch

--- a/debian/patches/tomllib.patch
+++ b/debian/patches/tomllib.patch
@@ -1,0 +1,43 @@
+--- a/dhpython/build/plugin_flit.py
++++ b/dhpython/build/plugin_flit.py
+@@ -27,9 +27,13 @@
+ import os
+ import os.path as osp
+ import shutil
++import sys
+ import sysconfig
+ try:
+-    import tomli
++    if sys.version_info >= (3, 11):
++        import tomllib
++    else:
++        import tomli as tomllib
+ except ModuleNotFoundError:
+     # Plugin still works, only needed for autodetection
+     pass
+--- a/dhpython/build/plugin_pyproject.py
++++ b/dhpython/build/plugin_pyproject.py
+@@ -24,9 +24,13 @@
+ import logging
+ import os.path as osp
+ import shutil
++import sys
+ import sysconfig
+ try:
+-    import tomli
++    if sys.version_info >= (3, 11):
++        import tomllib
++    else:
++        import tomli as tomllib
+ except ModuleNotFoundError:
+     # Plugin still works, only needed for autodetection
+     pass
+@@ -66,7 +70,7 @@
+ 
+         try:
+             with open('pyproject.toml', 'rb') as f:
+-                pyproject = tomli.load(f)
++                pyproject = tomllib.load(f)
+             if pyproject.get('build-system', {}).get('build-backend'):
+                 result += 10
+             else:

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (native)
+3.0 (quilt)


### PR DESCRIPTION
Ref: https://peps.python.org/pep-0680/